### PR TITLE
refactor: type `data` as `bytes memory`

### DIFF
--- a/src/CoprocessorAdapter.sol
+++ b/src/CoprocessorAdapter.sol
@@ -35,7 +35,7 @@ abstract contract CoprocessorAdapter is ICoprocessorCallback {
 
     /// @notice Issues a task to the coprocessor
     /// @param input ABI-encoded input data for the coprocessor
-    function callCoprocessor(bytes calldata input) internal {
+    function callCoprocessor(bytes memory input) internal {
         bytes32 inputHash = keccak256(input);
         computationSent[inputHash] = true;
         taskIssuer.issueTask(machineHash, input, address(this));


### PR DESCRIPTION
This allows contracts that inherit from `CoprocessorAdapter` to call `callCoprocessor` with `input` in memory (e.g. if ABI-encoded). This is backwards compatible as Solidity can implicitly convert byte arrays from `calldata` to `memory` (and it would need to do so either way in order to hash it).